### PR TITLE
Add hcl support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ name = "cfgrs"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "hcl-rs",
  "pico-args",
  "serde",
  "serde_json",
@@ -27,10 +28,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hcl-edit"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46510177a76e68ccd7d75c5af6dfc7d9bf14d5b274211cc35d5abe7f6e72d5b0"
+dependencies = [
+ "fnv",
+ "hcl-primitives",
+ "vecmap-rs",
+ "winnow",
+]
+
+[[package]]
+name = "hcl-primitives"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaef0959c97781fc9aba104a08e513a14f995b7c12fdcf940d94252d2e4fa884"
+dependencies = [
+ "itoa",
+ "kstring",
+ "ryu",
+ "serde",
+ "unicode-ident",
+]
+
+[[package]]
+name = "hcl-rs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba31dbfca0e197057f6d9a070cf87a68d93da5f551d4ad0d44e0f274f7179669"
+dependencies = [
+ "hcl-edit",
+ "hcl-primitives",
+ "indexmap",
+ "itoa",
+ "serde",
+ "vecmap-rs",
+]
 
 [[package]]
 name = "indexmap"
@@ -40,6 +86,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -47,6 +94,16 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "memchr"
@@ -138,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +256,15 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "vecmap-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d9c76f2c769d47dec11c6f4a9cd3be5e5e025a6bce297b07a311a3514ca97d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.86"
+hcl-rs = "0.18.0"
 pico-args = "0.5.0"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfgrs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "CLI helper tool for converting between configuration formats"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
  cfgrs is a small CLI helper tool for converting between different configuration formats.
  The current formats supported are:
+ * hcl
  * json
  * toml
  * yaml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub enum ConfigType {
     Json,
     Yaml,
     Toml,
+    Hcl,
 }
 
 #[derive(Debug, Serialize)]
@@ -14,6 +15,7 @@ pub enum ParsedInput {
     Json(serde_json::Value),
     Yaml(serde_yaml::Value),
     Toml(toml::Value),
+    Hcl(hcl::Body),
 }
 
 pub fn try_parse_all(input: &str) -> Result<ParsedInput> {
@@ -23,6 +25,8 @@ pub fn try_parse_all(input: &str) -> Result<ParsedInput> {
         Ok(ParsedInput::Yaml(parsed))
     } else if let Ok(parsed) = toml::from_str(input) {
         Ok(ParsedInput::Toml(parsed))
+    } else if let Ok(parsed) = hcl::from_str(input) {
+        Ok(ParsedInput::Hcl(parsed))
     } else {
         bail!(format!(
             "Failed to parse following input as valid json, yaml, or toml: {:?}",


### PR DESCRIPTION
This adds hcl support in a simple way by pulling in the hcl-rs dependency and then extending all of the enums accordingly.
As this is a new feature, a we increment the minor version number.